### PR TITLE
Fix basis rotation and MPS orthogonality in METTS collapse

### DIFF
--- a/src/checkpoint.jl
+++ b/src/checkpoint.jl
@@ -47,7 +47,7 @@ end
 Reads the last collapsed product state from the HDF5 file. Errors if
 the file cannot be read or the dataset is empty.
 """
-function read_last_product_state(filename::String, product_state_name::String)::Vector{Int}
+function read_last_product_state(filename::String, product_state_name::String)
     isfile(filename) || error("File '$filename' not found.")
     try
         product_state = h5open(filename, "r") do f

--- a/src/collapse.jl
+++ b/src/collapse.jl
@@ -1,13 +1,12 @@
 function collapse(psi::MPS, basis::AbstractString=nothing)
     if basis === nothing || basis == "Z"
-        return sample(psi)
+        return sample!(psi)
     elseif basis == "X"
         s = siteinds(psi)
         N = length(psi)
         H_gates = [op("H", s[n]) for n in 1:N]
         psi2 = apply(H_gates, psi)
-        orthogonalize!(psi2, 1)
-        return sample(psi2)
+        return sample!(psi2)
     else
         error("Invalid basis specified in METTS collapse.")
     end

--- a/src/collapse.jl
+++ b/src/collapse.jl
@@ -4,9 +4,8 @@ function collapse(psi::MPS, basis::AbstractString=nothing)
     elseif basis == "X"
         s = siteinds(psi)
         N = length(psi)
-        Ry_gates = [op("Ry", s[n], θ=π/2) for n in 1:N]
-        # Ry_gates = ops([("Ry", n, (θ=π / 2,)) for n in 1:N], s)
-        psi2 = apply(Ry_gates, psi)
+        H_gates = [op("H", s[n]) for n in 1:N]
+        psi2 = apply(H_gates, psi)
         orthogonalize!(psi2, 1)
         return sample(psi2)
     else
@@ -22,8 +21,8 @@ function collapse_with_qn(psi::MPS, basis::AbstractString=nothing)
         psi_noqn = dense(psi)
         s = siteinds(psi_noqn)
         N = length(psi_noqn)
-        Ry_gates = [op("Ry", s[n], θ=π/2) for n in 1:N]
-        psi_noqn = apply(Ry_gates, psi_noqn)
+        H_gates = [op("H", s[n]) for n in 1:N]
+        psi_noqn = apply(H_gates, psi_noqn)
         return sample!(psi_noqn)
     else
         error("Invalid basis specified in METTS collapse.")


### PR DESCRIPTION
Fixed the X-basis measurements. The old code was accidentally flipping the X directions backwards, i.e., the state X+ basis was mapped onto the Z- and the X- to -Z+. So, I replaced the rotation gate with the Hadamard gate. This ensures that the X basis is mapped onto the Z basis in the correct way.

Changed sample to sample!. Before, the code would crash because the state had the incorrect orthogonality center before sampling. Adding the ! forces ITensors to automatically fix the orthogonality center right.

Updated read_last_product_state function to also return vectors of strings, which is useful when collapsing from a mixed basis. As a result, the product state arrays now correspond to vectors of strings with the specific basis direction.